### PR TITLE
Updates ror-api-users URL to ror-tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Beginning with its Mar 2022 release, ROR is curated independently from GRID. Sem
 
 ## Support
 
-For help using ROR data, visit the [ROR support site](https://ror.readme.io) or post in the [ROR Tech Support Google Group](https://groups.google.com/a/ror.org/g/ror-api-users)
+For help using ROR data, visit the [ROR support site](https://ror.readme.io) or post in the [ROR Tech Support Google Group](https://groups.google.com/a/ror.org/g/ror-tech)


### PR DESCRIPTION
The URL https://groups.google.com/a/ror.org/g/ror-api-users/ doesn't redirect to https://groups.google.com/a/ror.org/g/ror-tech so I'm updating it in this repo's README.